### PR TITLE
Update default ElasticSearch version to 1.4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An Ansible role for installing [ElasticSearch](http://www.elasticsearch.org/).
 
 ## Role Variables
 
-- `elasticsearch_version` - Kibana version to install (default: `1.4.0`)
+- `elasticsearch_version` - Kibana version to install (default: `1.4.4`)
 - `elasticsearch_cluster_name` - ElasticSearch cluster name (default: `elasticsearch`)
 - `elasticsearch_bind_host` - Address ElasticSearch binds to (default: `0.0.0.0`)
 - `elasticsearch_tcp_port` - TCP port ElasticSearch binds to (default: `9300`)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-elasticsearch_version: "1.4.0"
+elasticsearch_version: "1.4.4"
 elasticsearch_cluster_name: "elasticsearch"
 elasticsearch_bind_host: "0.0.0.0"
 elasticsearch_tcp_port: "9300"

--- a/examples/roles.txt
+++ b/examples/roles.txt
@@ -1,1 +1,1 @@
-azavea.java,0.1.1
+azavea.java,0.2.1


### PR DESCRIPTION
This changeset bumps the default version of ElasticSearch to version 1.4.4. This is the minimum version of ElasticSearch required by Kibana 4.
