### PR TITLE
Add ElasticSearch AWS Cloud Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0
+
+- Add support to install elasticsearch cloud plugin
+
 ## 0.2.0
 
 - Add support for CORS over the HTTP endpoint.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ An Ansible role for installing [ElasticSearch](http://www.elasticsearch.org/).
 - `elasticsearch_http_port` - HTTP port ElasticSearch binds to (default: `9200`)
 - `elasticsearch_cors_enable` - Toggle CORS support (default: `false`)
 - `elasticsearch_cors_allow_origin` - Allow origin setting for CORS (default: `*`)
+- `elasticsearch_cloud_aws_plugin_install` - Install AWS [Cloud Plugin](https://github.com/elastic/elasticsearch-cloud-aws) for ElasticSearch (default: `false`)
+- `elasticsearch_cloud_aws_plugin_version` - Version of AWS Cloud Plugin to use (default: `2.4.1`)
+
+## Notes
+The ElasticSearch AWS Cloud Plugin is an optional install for this role. Configuration and usage is left to consumers of this role and may be required depending on how usages of AWS credentials is preferred.
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,5 @@ elasticsearch_tcp_port: "9300"
 elasticsearch_http_port: "9200"
 elasticsearch_cors_enable: "false"
 elasticsearch_cors_allow_origin: "*"
+elasticsearch_cloud_aws_plugin_install: false
+elasticsearch_cloud_aws_plugin_version: "2.4.1"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,3 +17,9 @@
 
 - name: Enable ElasticSearch service
   service: name=elasticsearch enabled=yes state=started
+
+- name: Install ElasticSearch Cloud Plugin
+  command: bin/plugin install elasticsearch/elasticsearch-cloud-aws/{{ elasticsearch_cloud_aws_plugin_version }}
+           chdir=/usr/share/elasticsearch
+           creates=/usr/share/elasticsearch/plugins/cloud-aws/elasticsearch-cloud-aws-{{ elasticsearch_cloud_aws_plugin_version }}.jar
+  when: elasticsearch_cloud_aws_plugin_install


### PR DESCRIPTION
This commit installs the ElasticSearch Cloud Plugin for AWS
which can be used to take snapshots of indices and push them
to S3
