### PR TITLE
Add support for Elasticsearch 2.x; break backward compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 0.1.1
 
-- Bump default version of ElasticSearch to 1.4.4.
+- Bump default version of Elasticsearch to 1.4.4.
 
 ## 0.1.0
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # ansible-elasticsearch
 
-An Ansible role for installing [ElasticSearch](http://www.elasticsearch.org/).
+An Ansible role for installing [Elasticsearch](https://www.elastic.co/products/elasticsearch).
 
 ## Role Variables
 
-- `elasticsearch_version` - ElasticSearch version to install (default: `1.4.4`)
-- `elasticsearch_cluster_name` - ElasticSearch cluster name (default: `elasticsearch`)
-- `elasticsearch_bind_host` - Address ElasticSearch binds to (default: `0.0.0.0`)
-- `elasticsearch_tcp_port` - TCP port ElasticSearch binds to (default: `9300`)
-- `elasticsearch_http_port` - HTTP port ElasticSearch binds to (default: `9200`)
+- `elasticsearch_version` - Elasticsearch version to install
+- `elasticsearch_short_version` - Elasticsearch short version
+- `elasticsearch_cluster_name` - Elasticsearch cluster name (default: `elasticsearch`)
+- `elasticsearch_data_dir` - Elasticsearch data directory (default: `/var/lib/elasticsearch`)
+- `elasticsearch_bind_host` - Address Elasticsearch binds to (default: `127.0.0.1`)
+- `elasticsearch_tcp_port` - TCP port Elasticsearch binds to (default: `9300`)
+- `elasticsearch_http_port` - HTTP port Elasticsearch binds to (default: `9200`)
 - `elasticsearch_cors_enable` - Toggle CORS support (default: `false`)
 - `elasticsearch_cors_allow_origin` - Allow origin setting for CORS (default: `*`)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,9 @@
 ---
-elasticsearch_version: "1.4.4"
+elasticsearch_version: "2.2.0"
+elasticsearch_short_version: "2.x"
 elasticsearch_cluster_name: "elasticsearch"
-elasticsearch_bind_host: "0.0.0.0"
+elasticsearch_data_dir: "/var/lib/elasticsearch"
+elasticsearch_bind_host: "127.0.0.1"
 elasticsearch_tcp_port: "9300"
 elasticsearch_http_port: "9200"
 elasticsearch_cors_enable: "false"

--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -6,13 +6,14 @@ VAGRANTFILE_API_VERSION = "2"
 # Ensure role dependencies are in place
 if [ "up", "provision" ].include?(ARGV.first) && File.directory?("roles") &&
   !(File.directory?("roles/azavea.java") || File.symlink?("roles/azavea.java"))
-  system("ansible-galaxy install --force -r roles.txt -p roles")
+  system("ansible-galaxy install --force -r roles.yml -p roles")
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/trusty64"
 
   config.vm.network "forwarded_port", guest: 9200, host: 9200
+  config.vm.network "forwarded_port", guest: 9300, host: 9300
 
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "site.yml"

--- a/examples/roles.txt
+++ b/examples/roles.txt
@@ -1,1 +1,0 @@
-azavea.java,0.2.1

--- a/examples/roles.yml
+++ b/examples/roles.yml
@@ -1,0 +1,2 @@
+- src: azavea.java
+  version: 0.2.1

--- a/examples/site.yml
+++ b/examples/site.yml
@@ -1,6 +1,9 @@
 ---
 - hosts: all
 
+  vars:
+    elasticsearch_bind_host: "0.0.0.0"
+
   pre_tasks:
     - name: Update APT cache
       apt: update_cache=yes

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
-- name: Restart ElasticSearch
+- name: Restart Elasticsearch
   service: name=elasticsearch state=restarted

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: Hector Castro
-  description: An Ansible role for installing ElasticSearch.
+  description: An Ansible role for installing Elasticsearch.
   company: Azavea Inc.
   license: Apache
   min_ansible_version: 1.2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,19 +1,27 @@
 ---
-- name: Configure ElasticSearch APT key
-  apt_key: url=http://packages.elasticsearch.org/GPG-KEY-elasticsearch state=present
+- name: Configure Elastic APT key
+  apt_key: url=https://packages.elastic.co/GPG-KEY-elasticsearch
+           state=present
 
-- name: Configure the ElasticSearch APT repositories
-  apt_repository: repo="deb http://packages.elasticsearch.org/elasticsearch/1.4/debian stable main"
+- name: Configure the Elastic APT repositories
+  apt_repository: repo="deb http://packages.elastic.co/elasticsearch/{{ elasticsearch_short_version }}/debian stable main"
                   state=present
 
-- name: Install ElasticSearch
-  apt: pkg=elasticsearch={{ elasticsearch_version }} state=present
+- name: Install Elasticsearch
+  apt: pkg="elasticsearch={{ elasticsearch_version }}"
+       state=present
 
-- name: Configure ElasticSearch
+- name: Configure Elasticsearch defaults
+  template: src=elasticsearch.j2
+            dest=/etc/default/elasticsearch
+  notify:
+    - Restart Elasticsearch
+
+- name: Configure Elasticsearch
   template: src=elasticsearch.yml.j2
             dest=/etc/elasticsearch/elasticsearch.yml
   notify:
-    - Restart ElasticSearch
+    - Restart Elasticsearch
 
-- name: Enable ElasticSearch service
-  service: name=elasticsearch enabled=yes state=started
+- name: Enable Elasticsearch service
+  service: name=elasticsearch enabled=yes

--- a/templates/elasticsearch.j2
+++ b/templates/elasticsearch.j2
@@ -1,0 +1,75 @@
+################################
+# Elasticsearch
+################################
+
+# Elasticsearch home directory
+#ES_HOME=/usr/share/elasticsearch
+
+# Elasticsearch configuration directory
+#CONF_DIR=/etc/elasticsearch
+
+# Elasticsearch data directory
+DATA_DIR={{ elasticsearch_data_dir }}
+
+# Elasticsearch logs directory
+#LOG_DIR=/var/log/elasticsearch
+
+# Elasticsearch PID directory
+#PID_DIR=/var/run/elasticsearch
+
+# Heap size defaults to 256m min, 1g max
+# Set ES_HEAP_SIZE to 50% of available RAM, but no more than 31g
+#ES_HEAP_SIZE=2g
+
+# Heap new generation
+#ES_HEAP_NEWSIZE=
+
+# Maximum direct memory
+#ES_DIRECT_SIZE=
+
+# Additional Java OPTS
+ES_JAVA_OPTS="-XX:-UseSuperWord"
+
+# Configure restart on package upgrade (true, every other setting will lead to not restarting)
+#ES_RESTART_ON_UPGRADE=true
+
+# Path to the GC log file
+#ES_GC_LOG_FILE=/var/log/elasticsearch/gc.log
+
+################################
+# Elasticsearch service
+################################
+
+# SysV init.d
+#
+# When executing the init script, this user will be used to run the elasticsearch service.
+# The default value is 'elasticsearch' and is declared in the init.d file.
+# Note that this setting is only used by the init script. If changed, make sure that
+# the configured user can read and write into the data, work, plugins and log directories.
+# For systemd service, the user is usually configured in file /usr/lib/systemd/system/elasticsearch.service
+#ES_USER=elasticsearch
+#ES_GROUP=elasticsearch
+
+# The number of seconds to wait before checking if Elasticsearch started successfully as a daemon process
+ES_STARTUP_SLEEP_TIME=5
+
+################################
+# System properties
+################################
+
+# Specifies the maximum file descriptor number that can be opened by this process
+# When using Systemd, this setting is ignored and the LimitNOFILE defined in
+# /usr/lib/systemd/system/elasticsearch.service takes precedence
+#MAX_OPEN_FILES=65535
+
+# The maximum number of bytes of memory that may be locked into RAM
+# Set to "unlimited" if you use the 'bootstrap.mlockall: true' option
+# in elasticsearch.yml (ES_HEAP_SIZE  must also be set).
+# When using Systemd, the LimitMEMLOCK property must be set
+# in /usr/lib/systemd/system/elasticsearch.service
+#MAX_LOCKED_MEMORY=unlimited
+
+# Maximum number of VMA (Virtual Memory Areas) a process can own
+# When using Systemd, this setting is ignored and the 'vm.max_map_count'
+# property is set at boot time in /usr/lib/sysctl.d/elasticsearch.conf
+#MAX_MAP_COUNT=262144

--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -1,389 +1,99 @@
-##################### Elasticsearch Configuration Example #####################
-
-# This file contains an overview of various configuration settings,
-# targeted at operations staff. Application developers should
-# consult the guide at <http://elasticsearch.org/guide>.
+# ======================== Elasticsearch Configuration =========================
 #
-# The installation procedure is covered at
-# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/setup.html>.
+# NOTE: Elasticsearch comes with reasonable defaults for most settings.
+#       Before you set out to tweak and tune the configuration, make sure you
+#       understand what are you trying to accomplish and the consequences.
 #
-# Elasticsearch comes with reasonable defaults for most settings,
-# so you can try it out without bothering with configuration.
+# The primary way of configuring a node is via this file. This template lists
+# the most important settings you may want to configure for a production cluster.
 #
-# Most of the time, these defaults are just fine for running a production
-# cluster. If you're fine-tuning your cluster, or wondering about the
-# effect of certain configuration option, please _do ask_ on the
-# mailing list or IRC channel [http://elasticsearch.org/community].
-
-# Any element in the configuration can be replaced with environment variables
-# by placing them in ${...} notation. For example:
+# Please see the documentation for further information on configuration options:
+# <http://www.elastic.co/guide/en/elasticsearch/reference/current/setup-configuration.html>
 #
-#node.rack: ${RACK_ENV_VAR}
-
-# For information on supported formats and syntax for the config file, see
-# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/setup-configuration.html>
-
-
-################################### Cluster ###################################
-
-# Cluster name identifies your cluster for auto-discovery. If you're running
-# multiple clusters on the same network, make sure you're using unique names.
+# ---------------------------------- Cluster -----------------------------------
+#
+# Use a descriptive name for your cluster:
 #
 cluster.name: {{ elasticsearch_cluster_name }}
-
-
-#################################### Node #####################################
-
-# Node names are generated dynamically on startup, so you're relieved
-# from configuring them manually. You can tie this node to a specific name:
 #
-#node.name: "Franz Kafka"
-
-# Every node can be configured to allow or deny being eligible as the master,
-# and to allow or deny to store the data.
+# ------------------------------------ Node ------------------------------------
 #
-# Allow this node to be eligible as a master node (enabled by default):
+# Use a descriptive name for the node:
 #
-#node.master: true
+# node.name: node-1
 #
-# Allow this node to store data (enabled by default):
+# Add custom attributes to the node:
 #
-#node.data: true
-
-# You can exploit these settings to design advanced cluster topologies.
+# node.rack: r1
 #
-# 1. You want this node to never become a master node, only to hold data.
-#    This will be the "workhorse" of your cluster.
+# ----------------------------------- Paths ------------------------------------
 #
-#node.master: false
-#node.data: true
+# Path to directory where to store the data (separate multiple locations by comma):
 #
-# 2. You want this node to only serve as a master: to not store any data and
-#    to have free resources. This will be the "coordinator" of your cluster.
+# path.data: /path/to/data
 #
-#node.master: true
-#node.data: false
-#
-# 3. You want this node to be neither master nor data node, but
-#    to act as a "search load balancer" (fetching data from nodes,
-#    aggregating results, etc.)
-#
-#node.master: false
-#node.data: false
-
-# Use the Cluster Health API [http://localhost:9200/_cluster/health], the
-# Node Info API [http://localhost:9200/_nodes] or GUI tools
-# such as <http://www.elasticsearch.org/overview/marvel/>,
-# <http://github.com/karmi/elasticsearch-paramedic>,
-# <http://github.com/lukas-vlcek/bigdesk> and
-# <http://mobz.github.com/elasticsearch-head> to inspect the cluster state.
-
-# A node can have generic attributes associated with it, which can later be used
-# for customized shard allocation filtering, or allocation awareness. An attribute
-# is a simple key value pair, similar to node.key: value, here is an example:
-#
-#node.rack: rack314
-
-# By default, multiple nodes are allowed to start from the same installation location
-# to disable it, set the following:
-#node.max_local_storage_nodes: 1
-
-
-#################################### Index ####################################
-
-# You can set a number of options (such as shard/replica options, mapping
-# or analyzer definitions, translog settings, ...) for indices globally,
-# in this file.
-#
-# Note, that it makes more sense to configure index settings specifically for
-# a certain index, either when creating it or by using the index templates API.
-#
-# See <http://elasticsearch.org/guide/en/elasticsearch/reference/current/index-modules.html> and
-# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/indices-create-index.html>
-# for more information.
-
-# Set the number of shards (splits) of an index (5 by default):
-#
-#index.number_of_shards: 5
-
-# Set the number of replicas (additional copies) of an index (1 by default):
-#
-#index.number_of_replicas: 1
-
-# Note, that for development on a local machine, with small indices, it usually
-# makes sense to "disable" the distributed features:
-#
-#index.number_of_shards: 1
-#index.number_of_replicas: 0
-
-# These settings directly affect the performance of index and search operations
-# in your cluster. Assuming you have enough machines to hold shards and
-# replicas, the rule of thumb is:
-#
-# 1. Having more *shards* enhances the _indexing_ performance and allows to
-#    _distribute_ a big index across machines.
-# 2. Having more *replicas* enhances the _search_ performance and improves the
-#    cluster _availability_.
-#
-# The "number_of_shards" is a one-time setting for an index.
-#
-# The "number_of_replicas" can be increased or decreased anytime,
-# by using the Index Update Settings API.
-#
-# Elasticsearch takes care about load balancing, relocating, gathering the
-# results from nodes, etc. Experiment with different settings to fine-tune
-# your setup.
-
-# Use the Index Status API (<http://localhost:9200/A/_status>) to inspect
-# the index status.
-
-
-#################################### Paths ####################################
-
-# Path to directory containing configuration (this file and logging.yml):
-#
-#path.conf: /path/to/conf
-
-# Path to directory where to store index data allocated for this node.
-#
-#path.data: /path/to/data
-#
-# Can optionally include more than one location, causing data to be striped across
-# the locations (a la RAID 0) on a file level, favouring locations with most free
-# space on creation. For example:
-#
-#path.data: /path/to/data1,/path/to/data2
-
-# Path to temporary files:
-#
-#path.work: /path/to/work
-
 # Path to log files:
 #
-#path.logs: /path/to/logs
-
-# Path to where plugins are installed:
+# path.logs: /path/to/logs
 #
-#path.plugins: /path/to/plugins
-
-
-#################################### Plugin ###################################
-
-# If a plugin listed here is not installed for current node, the node will not start.
+# ----------------------------------- Memory -----------------------------------
 #
-#plugin.mandatory: mapper-attachments,lang-groovy
-
-
-################################### Memory ####################################
-
-# Elasticsearch performs poorly when JVM starts swapping: you should ensure that
-# it _never_ swaps.
+# Lock the memory on startup:
 #
-# Set this property to true to lock the memory:
+# bootstrap.mlockall: true
 #
-#bootstrap.mlockall: true
-
-# Make sure that the ES_MIN_MEM and ES_MAX_MEM environment variables are set
-# to the same value, and that the machine has enough memory to allocate
-# for Elasticsearch, leaving enough memory for the operating system itself.
+# Make sure that the `ES_HEAP_SIZE` environment variable is set to about half the memory
+# available on the system and that the owner of the process is allowed to use this limit.
 #
-# You should also make sure that the Elasticsearch process is allowed to lock
-# the memory, eg. by using `ulimit -l unlimited`.
-
-
-############################## Network And HTTP ###############################
-
-# Elasticsearch, by default, binds itself to the 0.0.0.0 address, and listens
-# on port [9200-9300] for HTTP traffic and on port [9300-9400] for node-to-node
-# communication. (the range means that if the port is busy, it will automatically
-# try the next port).
-
-# Set the bind address specifically (IPv4 or IPv6):
+# Elasticsearch performs poorly when the system is swapping the memory.
 #
-network.bind_host: {{ elasticsearch_bind_host }}
-
-# Set the address other nodes will use to communicate with this node. If not
-# set, it is automatically derived. It must point to an actual IP address.
+# ---------------------------------- Network -----------------------------------
 #
-#network.publish_host: 192.168.0.1
-
-# Set both 'bind_host' and 'publish_host':
+# Set the bind address to a specific IP (IPv4 or IPv6):
 #
-#network.host: 192.168.0.1
-
-# Set a custom port for the node to node communication (9300 by default):
+network.host: {{ elasticsearch_bind_host }}
 #
-transport.tcp.port: {{ elasticsearch_tcp_port }}
-
-# Enable compression for all communication between nodes (disabled by default):
-#
-#transport.tcp.compress: true
-
-# Set a custom port to listen for HTTP traffic:
+# Set a custom port for HTTP:
 #
 http.port: {{ elasticsearch_http_port }}
 
-# Set a custom allowed content length:
-#
-#http.max_content_length: 100mb
-
-# Disable HTTP completely:
-#
-#http.enabled: false
-
-# CORS
 http.cors.enabled: {{ elasticsearch_cors_enable }}
 http.cors.allow-origin: "{{ elasticsearch_cors_allow_origin }}"
 
-
-################################### Gateway ###################################
-
-# The gateway allows for persisting the cluster state between full cluster
-# restarts. Every change to the state (such as adding an index) will be stored
-# in the gateway, and when the cluster starts up for the first time,
-# it will read its state from the gateway.
-
-# There are several types of gateway implementations. For more information, see
-# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/modules-gateway.html>.
-
-# The default gateway type is the "local" gateway (recommended):
+transport.tcp.port: {{ elasticsearch_tcp_port }}
 #
-#gateway.type: local
-
-# Settings below control how and when to start the initial recovery process on
-# a full cluster restart (to reuse as much local data as possible when using shared
-# gateway).
-
-# Allow recovery process after N nodes in a cluster are up:
+# For more information, see the documentation at:
+# <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html>
 #
-#gateway.recover_after_nodes: 1
-
-# Set the timeout to initiate the recovery process, once the N nodes
-# from previous setting are up (accepts time value):
+# --------------------------------- Discovery ----------------------------------
 #
-#gateway.recover_after_time: 5m
-
-# Set how many nodes are expected in this cluster. Once these N nodes
-# are up (and recover_after_nodes is met), begin recovery process immediately
-# (without waiting for recover_after_time to expire):
+# Pass an initial list of hosts to perform discovery when new node is started:
+# The default list of hosts is ["127.0.0.1", "[::1]"]
 #
-#gateway.expected_nodes: 2
-
-
-############################# Recovery Throttling #############################
-
-# These settings allow to control the process of shards allocation between
-# nodes during initial recovery, replica allocation, rebalancing,
-# or when adding and removing nodes.
-
-# Set the number of concurrent recoveries happening on a node:
+# discovery.zen.ping.unicast.hosts: ["host1", "host2"]
 #
-# 1. During the initial recovery
+# Prevent the "split brain" by configuring the majority of nodes (total number of nodes / 2 + 1):
 #
-#cluster.routing.allocation.node_initial_primaries_recoveries: 4
+# discovery.zen.minimum_master_nodes: 3
 #
-# 2. During adding/removing nodes, rebalancing, etc
+# For more information, see the documentation at:
+# <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery.html>
 #
-#cluster.routing.allocation.node_concurrent_recoveries: 2
-
-# Set to throttle throughput when recovering (eg. 100mb, by default 20mb):
+# ---------------------------------- Gateway -----------------------------------
 #
-#indices.recovery.max_bytes_per_sec: 20mb
-
-# Set to limit the number of open concurrent streams when
-# recovering a shard from a peer:
+# Block initial recovery after a full cluster restart until N nodes are started:
 #
-#indices.recovery.concurrent_streams: 5
-
-
-################################## Discovery ##################################
-
-# Discovery infrastructure ensures nodes can be found within a cluster
-# and master node is elected. Multicast discovery is the default.
-
-# Set to ensure a node sees N other master eligible nodes to be considered
-# operational within the cluster. This should be set to a quorum/majority of
-# the master-eligible nodes in the cluster.
+# gateway.recover_after_nodes: 3
 #
-#discovery.zen.minimum_master_nodes: 1
-
-# Set the time to wait for ping responses from other nodes when discovering.
-# Set this option to a higher value on a slow or congested network
-# to minimize discovery failures:
+# For more information, see the documentation at:
+# <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-gateway.html>
 #
-#discovery.zen.ping.timeout: 3s
-
-# For more information, see
-# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/modules-discovery-zen.html>
-
-# Unicast discovery allows to explicitly control which nodes will be used
-# to discover the cluster. It can be used when multicast is not present,
-# or to restrict the cluster communication-wise.
+# ---------------------------------- Various -----------------------------------
 #
-# 1. Disable multicast discovery (enabled by default):
+# Disable starting multiple nodes on a single system:
 #
-#discovery.zen.ping.multicast.enabled: false
+# node.max_local_storage_nodes: 1
 #
-# 2. Configure an initial list of master nodes in the cluster
-#    to perform discovery when new nodes (master or data) are started:
+# Require explicit names when deleting indices:
 #
-#discovery.zen.ping.unicast.hosts: ["host1", "host2:port"]
-
-# EC2 discovery allows to use AWS EC2 API in order to perform discovery.
-#
-# You have to install the cloud-aws plugin for enabling the EC2 discovery.
-#
-# For more information, see
-# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/modules-discovery-ec2.html>
-#
-# See <http://elasticsearch.org/tutorials/elasticsearch-on-ec2/>
-# for a step-by-step tutorial.
-
-# GCE discovery allows to use Google Compute Engine API in order to perform discovery.
-#
-# You have to install the cloud-gce plugin for enabling the GCE discovery.
-#
-# For more information, see <https://github.com/elasticsearch/elasticsearch-cloud-gce>.
-
-# Azure discovery allows to use Azure API in order to perform discovery.
-#
-# You have to install the cloud-azure plugin for enabling the Azure discovery.
-#
-# For more information, see <https://github.com/elasticsearch/elasticsearch-cloud-azure>.
-
-################################## Slow Log ##################################
-
-# Shard level query and fetch threshold logging.
-
-#index.search.slowlog.threshold.query.warn: 10s
-#index.search.slowlog.threshold.query.info: 5s
-#index.search.slowlog.threshold.query.debug: 2s
-#index.search.slowlog.threshold.query.trace: 500ms
-
-#index.search.slowlog.threshold.fetch.warn: 1s
-#index.search.slowlog.threshold.fetch.info: 800ms
-#index.search.slowlog.threshold.fetch.debug: 500ms
-#index.search.slowlog.threshold.fetch.trace: 200ms
-
-#index.indexing.slowlog.threshold.index.warn: 10s
-#index.indexing.slowlog.threshold.index.info: 5s
-#index.indexing.slowlog.threshold.index.debug: 2s
-#index.indexing.slowlog.threshold.index.trace: 500ms
-
-################################## GC Logging ################################
-
-#monitor.jvm.gc.young.warn: 1000ms
-#monitor.jvm.gc.young.info: 700ms
-#monitor.jvm.gc.young.debug: 400ms
-
-#monitor.jvm.gc.old.warn: 10s
-#monitor.jvm.gc.old.info: 5s
-#monitor.jvm.gc.old.debug: 2s
-
-################################## Security ################################
-
-# Uncomment if you want to enable JSONP as a valid return transport on the
-# http server. With this enabled, it may pose a security risk, so disabling
-# it unless you need it is recommended (it is disabled by default).
-#
-#http.jsonp.enable: true
+# action.destructive_requires_name: true


### PR DESCRIPTION
Install and configure Elasticsearch 2.x from the Elastic APT repositories.

Resolves #5

---

**Testing**

``` bash
$ cd examples
$ vagrant up
$ curl localhost:9200/
{
  "name" : "Vengeance",
  "cluster_name" : "elasticsearch",
  "version" : {
    "number" : "2.2.0",
    "build_hash" : "8ff36d139e16f8720f2947ef62c8167a888992fe",
    "build_timestamp" : "2016-01-27T13:32:39Z",
    "build_snapshot" : false,
    "lucene_version" : "5.4.1"
  },
  "tagline" : "You Know, for Search"
}
```
